### PR TITLE
Add changelog to releases

### DIFF
--- a/.github/workflows/vyos-rolling-nightly-build.yml
+++ b/.github/workflows/vyos-rolling-nightly-build.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Git clone vyos-build
         run: git clone -b current --single-branch https://github.com/vyos/vyos-build
 
+      - name: Git clone vyos-1x
+        run: git clone -b current --single-branch https://github.com/vyos/vyos-1x
+
       - name: Build ISO (for Smoketest)
         run: |
           docker run --rm --privileged -v ./vyos-build/:/vyos -w /vyos vyos/vyos-build:current sudo --preserve-env ./build-vyos-image --architecture amd64 --build-by "autobuild@vyos.net" --vyos-mirror https://rolling-packages.vyos.net/current/ --debian-mirror http://deb.debian.org/debian/ --build-type release --custom-package vyos-1x-smoketest --version "${VYOS_VERSION}" iso
@@ -129,6 +132,57 @@ jobs:
               }
             ]
 
+      - name: last-success-build
+        run: |
+          START_TIME=$(gh run list -s success -L 1 -w "VyOS rolling nightly build" --json updatedAt | jq .[0].updatedAt)
+          cd ./vyos-build
+          echo "CHANGELOG_COMMIT_build=$(git log --since "$START_TIME" --format="%H" --reverse | head -n1)" >> $GITHUB_ENV
+          cd ../vyos-1x
+          echo "CHANGELOG_COMMIT_1x=$(git log --since "$START_TIME" --format="%H" --reverse | head -n1)" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: generate-1x-changelog
+        id: generate-1x-changelog
+        uses: mikepenz/release-changelog-builder-action@v4.1.0
+        with:
+          owner: "vyos"
+          repo: "vyos-1x"
+          fetchReviewers: false
+          fromTag: ${{ env.CHANGELOG_COMMIT_1x }}
+          toTag: HEAD
+          configurationJson: |
+            {
+              "categories": [{"title": "", "labels": []}],
+              "template": "#{{CHANGELOG}}",
+              "pr_template": "- #{{TITLE}}\n   - PR: vyos/vyos-1x##{{NUMBER}}"
+            }
+        if: ${{ env.CHANGELOG_COMMIT_1x != '' }}
+
+      - name: generate-build-changelog
+        id: generate-build-changelog
+        uses: mikepenz/release-changelog-builder-action@v4.1.0
+        with:
+          owner: "vyos"
+          repo: "vyos-build"
+          fetchReviewers: false
+          fromTag: ${{ env.CHANGELOG_COMMIT_build }}
+          toTag: HEAD
+          configurationJson: |
+            {
+              "categories": [{"title": "", "labels": []}],
+              "template": "#{{CHANGELOG}}",
+              "pr_template": "- #{{TITLE}}\n   - PR: vyos/vyos-build##{{NUMBER}}"
+            }
+        if: ${{ env.CHANGELOG_COMMIT_build != '' }}
+
+      - name: write-changelog
+        run: |
+          echo -e "## vyos-1x\n" > CHANGELOG.md
+          echo -e "${{ steps.generate-1x-changelog.outputs.changelog || 'No changes' }}\n" >> CHANGELOG.md
+          echo -e "## vyos-build\n" >> CHANGELOG.md
+          echo -e "${{ steps.generate-build-changelog.outputs.changelog || 'No changes' }}" >> CHANGELOG.md
+
       - name: Create autocommit and tag
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
@@ -138,6 +192,7 @@ jobs:
       - name: Publish release
         uses: softprops/action-gh-release@v1
         with:
+          body_path: CHANGELOG.md
           tag_name: ${{ env.VYOS_VERSION }}
           fail_on_unmatched_files: true
           files: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.DS_Store
 vyos-build/
+vyos-1x/
 vyos-*-amd64.iso*


### PR DESCRIPTION
This adds PRs from `vyos-1x` and `vyos-build` since last successful run to the release notes.

Example output: https://github.com/sarthurdev/vyos-rolling-nightly-builds/releases/tag/1.5-rolling-202312312226