### PR TITLE
general: T8595: add CLAUDE.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,12 +7,12 @@ Public scheduler repo for the VyOS nightly ISO build. Runs `nightly-build.yml` d
 - GitHub Actions only (one orchestration workflow + CLA gate).
 - Minisign for signature: public key at `minisign.pub` (verifiable by ISO consumers).
 - `version.json` records the current latest build URL/version/timestamp.
-- Helper scripts in `bin/`.
+- Vendored `minisign` static binary in `bin/` (used for ISO signing at workflow runtime).
 
 ## Build / test / run
 The nightly run is automatic. Manual trigger via `workflow_dispatch` with inputs:
 - `BUILD_BY` (default `autobuild@vyos.net`)
-- `build_version` (default `1.5-rolling-<ISO8601>`)
+- `build_version` (default `1.5-rolling-YYYYMMDDHHMM`, e.g. `1.5-rolling-202604291200`)
 - `SKIP_SMOKETEST_RAID1`, `SKIP_SMOKETEST_CLI`, `SKIP_SMOKETEST_CONFIG`, `SKIP_SMOKETEST_TPM` (booleans)
 - `SKIP_RELEASE_PUBLISHING`, `SKIP_SLACK_NOTIFICATIONS`
 
@@ -27,7 +27,7 @@ minisign -V -p minisign.pub -m vyos-<ver>-amd64.iso
 ## Repository layout
 - `.github/workflows/nightly-build.yml` — orchestration (cron + dispatch).
 - `.github/workflows/cla-check.yml` — CLA gate via `vyos/vyos-cla-signatures/.github/workflows/cla-reusable.yml@current`.
-- `bin/` — helper scripts.
+- `bin/` — vendored `minisign` static binary for ISO signing.
 - `minisign.pub` — public verification key (committed).
 - `version.json` — most recent build metadata (URL, version, timestamp).
 - `CHANGELOG.md`, `README.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# CLAUDE.md
+
+## Project purpose
+Public scheduler repo for the VyOS nightly ISO build. Runs `nightly-build.yml` daily at 00:00 UTC, builds a rolling ISO via the `vyos-build` toolchain, signs it with minisign, and publishes a GitHub Release that is linked from https://vyos.net/get/nightly-builds/.
+
+## Tech stack
+- GitHub Actions only (one orchestration workflow + CLA gate).
+- Minisign for signature: public key at `minisign.pub` (verifiable by ISO consumers).
+- `version.json` records the current latest build URL/version/timestamp.
+- Helper scripts in `bin/`.
+
+## Build / test / run
+The nightly run is automatic. Manual trigger via `workflow_dispatch` with inputs:
+- `BUILD_BY` (default `autobuild@vyos.net`)
+- `build_version` (default `1.5-rolling-<ISO8601>`)
+- `SKIP_SMOKETEST_RAID1`, `SKIP_SMOKETEST_CLI`, `SKIP_SMOKETEST_CONFIG`, `SKIP_SMOKETEST_TPM` (booleans)
+- `SKIP_RELEASE_PUBLISHING`, `SKIP_SLACK_NOTIFICATIONS`
+
+Verifying a published ISO:
+```
+wget https://github.com/vyos/vyos-nightly-build/raw/refs/heads/current/minisign.pub
+wget <release>/vyos-<ver>-amd64.iso
+wget <release>/vyos-<ver>-amd64.iso.minisig
+minisign -V -p minisign.pub -m vyos-<ver>-amd64.iso
+```
+
+## Repository layout
+- `.github/workflows/nightly-build.yml` — orchestration (cron + dispatch).
+- `.github/workflows/cla-check.yml` — CLA gate via `vyos/vyos-cla-signatures/.github/workflows/cla-reusable.yml@current`.
+- `bin/` — helper scripts.
+- `minisign.pub` — public verification key (committed).
+- `version.json` — most recent build metadata (URL, version, timestamp).
+- `CHANGELOG.md`, `README.md`.
+
+## Cross-repo context
+- Consumes the full build chain: `vyos/vyos-build` (toolchain) which in turn pulls per-package `.deb`s built via `VyOS-Networks/vyos-build-packages` from the 14 source repos in `repos.toml`.
+- The reusable workflows in `vyos/.github` and the `pr-mirror-repo-sync.yml` pipeline don't touch this repo directly — this is a scheduler, not a code repo.
+- Sibling reusable build workflows for release trains live in `VyOS-Networks/vyos-stream-builds` (`vyos-reusable-build.yml`, `vyos-reusable-vpp-build.yml`, train-specific reusables for `circinus`/`sagitta`).
+- A predecessor exists at `VyOS-Networks/vyos-rolling-nightly-builds` (stale, last push 2024-06-01) — superseded by this repo.
+- Release artifacts feed end-user-facing documentation in `vyos/vyos-documentation`.
+
+## Conventions
+- Commit/PR title: `component: T12345: description` (Phorge task ID at https://vyos.dev) where applicable.
+- Default branch: `current`. ISO version strings carry the rolling timestamp form.
+- Many repo-level secrets (the orchestration needs cross-org PATs, signing keys, Slack tokens, release publishers) — managed by ops; never committed.
+- ISO signing key is sensitive: rotation is a coordinated security event.
+
+## Mirror relationship
+Mirror twin: `VyOS-Networks/vyos-nightly-build`. Treat the `vyos/*` side as canonical (this is a public, end-user-facing repo).
+
+## Notes for future contributors
+- **Do not commit secrets** — all credentials and signing material flow through GitHub Actions secrets injected at workflow runtime.
+- Skip toggles (`SKIP_SMOKETEST_*`, `SKIP_RELEASE_PUBLISHING`) exist for ad-hoc rebuilds; default everything OFF for normal nightly cadence.
+- The published `version.json` is read by the website (`sentrium/next-js-vyos`) and download-page tooling; format is an array of objects (`url`, `version`, `timestamp`).
+- Release notes pipeline lives separately in `andamasov/release-notes`; this repo only assembles the ISO and publishes the GitHub Release.
+
+---
+
+This file is mirrored on Confluence: [`vyos/vyos-nightly-build`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818053269). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,3 @@ Mirror twin: `VyOS-Networks/vyos-nightly-build`. Treat the `vyos/*` side as cano
 - Skip toggles (`SKIP_SMOKETEST_*`, `SKIP_RELEASE_PUBLISHING`) exist for ad-hoc rebuilds; default everything OFF for normal nightly cadence.
 - The published `version.json` is read by the website (`sentrium/next-js-vyos`) and download-page tooling; format is an array of objects (`url`, `version`, `timestamp`).
 - Release notes pipeline lives separately in `andamasov/release-notes`; this repo only assembles the ISO and publishes the GitHub Release.
-
----
-
-This file is mirrored on Confluence: [`vyos/vyos-nightly-build`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818053269). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.


### PR DESCRIPTION
## Summary

Adds a single source of truth for repo-level agent instructions, plus three symlinks so different agentic tools all read the same content from one canonical file.

**Files added:**

| Path | Type | Consumed by |
|---|---|---|
| `CLAUDE.md` | real file | Claude Code, Anthropic agents |
| `AGENTS.md` | symlink → `CLAUDE.md` | tools that follow the AGENTS.md convention (e.g. OpenAI Codex) |
| `.cursorrules` | symlink → `CLAUDE.md` | Cursor |
| `.github/copilot-instructions.md` | symlink → `../CLAUDE.md` | GitHub Copilot ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide)) |

**Rationale**

- One source of truth — guidance lives in `CLAUDE.md`, the symlinks are zero-content. No drift between four files.
- Each agentic tool reads its canonical filename and gets the same content.
- Mac/Linux dev environments handle symlinks natively. Windows checkouts may render them as text files containing the target path; the canonical `CLAUDE.md` is unaffected and still rendered/served correctly by GitHub.

**Out of scope**

Path-specific Copilot instructions (`.github/instructions/*.instructions.md`) need YAML frontmatter (`applyTo:`) and target specific globs, so they cannot be symlinks. Not added here; they can be authored as separate small files per-repo if/when narrow path-scoped guidance is needed.

Tracked under [T8595](https://vyos.dev/T8595).

## Test plan

- [ ] `CLAUDE.md` renders on GitHub.
- [ ] `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md` resolve to CLAUDE.md content (`readlink` returns the right target).
- [ ] CI passes.

🤖 Generated by [robots](https://vyos.io)
