### PR TITLE
docs(agents-md): correct ISO artifact name in verify example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,12 +16,12 @@ The nightly run is automatic. Manual trigger via `workflow_dispatch` with inputs
 - `SKIP_SMOKETEST_RAID1`, `SKIP_SMOKETEST_CLI`, `SKIP_SMOKETEST_CONFIG`, `SKIP_SMOKETEST_TPM` (booleans)
 - `SKIP_RELEASE_PUBLISHING`, `SKIP_SLACK_NOTIFICATIONS`
 
-Verifying a published ISO:
+Verifying a published ISO (artifact name is `vyos-<ver>-generic-amd64.iso` per `version.json`):
 ```
 wget https://github.com/vyos/vyos-nightly-build/raw/refs/heads/current/minisign.pub
-wget <release>/vyos-<ver>-amd64.iso
-wget <release>/vyos-<ver>-amd64.iso.minisig
-minisign -V -p minisign.pub -m vyos-<ver>-amd64.iso
+wget <release>/vyos-<ver>-generic-amd64.iso
+wget <release>/vyos-<ver>-generic-amd64.iso.minisig
+minisign -V -p minisign.pub -m vyos-<ver>-generic-amd64.iso
 ```
 
 ## Repository layout


### PR DESCRIPTION
## Summary

One correction to `AGENTS.md` surfaced by Copilot review on the [VyOS-Networks/vyos-nightly-build#45](https://github.com/VyOS-Networks/vyos-nightly-build/pull/45) mirror twin. Verified against this repo's actual state — the other 3 Copilot findings were stale-twin artifacts (bin/minisign exists here, workflow_dispatch inputs match exactly, cla-check.yml exists).

## Changes

- **Verify example ISO name**: `vyos-<ver>-amd64.iso` → `vyos-<ver>-generic-amd64.iso`. The published artifact is named `…-generic-amd64.iso` per the current `version.json` (release tag `2026.05.09-0042-rolling` → `vyos-2026.05.09-0042-rolling-generic-amd64.iso`). Without `generic-`, the copy-pasted `wget` commands return 404.

## Test plan

- [ ] Confirm `version.json` filename pattern
- [ ] Copy-paste the verify block with a real release ver and confirm both `.iso` and `.minisig` resolve

Refs T8595.

🤖 Generated by [robots](https://vyos.io)