### PR TITLE
ci: T8947: fix current→rolling branch-ref drift in nightly-build (rollout 1c follow-up)

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -306,7 +306,7 @@ jobs:
       - test_encrypted_config_tpm
       - build_generic_iso
     runs-on: ubuntu-24.04
-    if: ${{ failure() && (github.ref == 'refs/heads/current') && !inputs.SKIP_SLACK_NOTIFICATIONS }}
+    if: ${{ failure() && (github.ref == 'refs/heads/rolling') && !inputs.SKIP_SLACK_NOTIFICATIONS }}
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -388,7 +388,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
-    if: github.ref_name == 'current'
+    if: github.ref_name == 'rolling'
     steps:
       - uses: actions/checkout@v4
       - name: Clone vyos-build repo


### PR DESCRIPTION
## What

Rollout 1c ([IS-503](https://vyos.atlassian.net/browse/IS-503)) renamed this repo's default branch `current` → `rolling`, but the branch-rename API does not edit workflow content. Two job-level `if:` guards still gate on the old branch name, so they never fire when the workflow runs on `rolling`:

- `:309` — Slack failure-notification job: `github.ref == 'refs/heads/current'` → failure alerts were **silently suppressed**
- `:391` — retag/publish job: `github.ref_name == 'current'` → conditional never matched

Both now reference `rolling`.

## Verification

Confirmed empirically that raw git does **not** follow the rename redirect (only the REST API does), so the old guards were genuinely dead on `rolling`:

```
git ls-remote https://github.com/vyos/vyos-1x.git --short current   # → empty (renamed)
git ls-remote https://github.com/vyos/vyos-1x.git --short rolling   # → resolves
```

Diff is 2 lines (literal branch-name strings only — no logic change, no untrusted input).

## Scope

Cat 1 (branch-ref drift) only. The Docker-tag (`vyos/vyos-build:current`) and Debian-mirror-path (`packages.vyos.net/repositories/current/`) references in this file are **intentionally left untouched** — they are gated on confirmation from the build-pipeline / infra owners that those surfaces moved to `rolling` (tracked as Cat 2 / Cat 3 in the companion tickets).

## Tracking

- Jira: [IS-504](https://vyos.atlassian.net/browse/IS-504) (companion to [IS-503](https://vyos.atlassian.net/browse/IS-503))
- Phorge: T8947 (subtask of T8943)

🤖 Generated by [robots](https://vyos.io)

[IS-503]: https://vyos.atlassian.net/browse/IS-503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IS-504]: https://vyos.atlassian.net/browse/IS-504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ